### PR TITLE
Adds URL to constructor

### DIFF
--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -1,14 +1,15 @@
 #%%
 class Aliasor:
-    def __init__(self, alias_file=None):
+    def __init__(self, *, alias_file=None, alias_url=None):
         import json
 
         if alias_file is None:
             import urllib.request, json
 
-            with urllib.request.urlopen(
-                "https://raw.githubusercontent.com/cov-lineages/pango-designation/master/pango_designation/alias_key.json"
-            ) as data:
+            if not alias_url:
+                alias_url = "https://raw.githubusercontent.com/cov-lineages/pango-designation/master/pango_designation/alias_key.json"
+
+            with urllib.request.urlopen(alias_url) as data:
                 file = json.load(data)
 
         else:
@@ -83,6 +84,5 @@ class Aliasor:
         if name_split[(3 * up_to + 1) :] == []:
             return alias
         return alias + "." + ".".join(name_split[(3 * up_to + 1) :])
-
 
 # %%

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -58,7 +58,7 @@ def test_double_alias_uncompression():
     assert aliasor.uncompress('BE.1') == 'B.1.1.529.5.3.1.1'
 
 def test_read_from_file(datadir):
-    aliasor = Aliasor(datadir.join('alias_key.json'))
+    aliasor = Aliasor(alias_file=datadir.join('alias_key.json'))
     assert aliasor.compress('B.1.1.529.1') == 'BA.1'
 
 def test_partial_alias_up_to():

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -61,6 +61,12 @@ def test_read_from_file(datadir):
     aliasor = Aliasor(alias_file=datadir.join('alias_key.json'))
     assert aliasor.compress('B.1.1.529.1') == 'BA.1'
 
+def test_read_from_url():
+    url = "https://raw.githubusercontent.com/cov-lineages/pango-designation/master/pango_designation/alias_key.json"
+    aliasor = Aliasor(alias_url=url)
+    assert aliasor.compress('B.1.1.529.1') == 'BA.1'
+    assert aliasor.uncompress('BE.1') == 'B.1.1.529.5.3.1.1'
+
 def test_partial_alias_up_to():
     aliasor = Aliasor()
     assert aliasor.partial_compress('B.1.1.529.1.2', up_to = 0) == 'B.1.1.529.1.2'


### PR DESCRIPTION
### Description of proposed changes    
It is intended to allow for #7 url proposal. 

This proposal modified the existing constructor to take in required, named arguments. If you don't use the default constructor, then you must specify the argument you are setting `Aliasor(alias_file=<file>)`. This changes the behavior of the existing file argument as you can no longer call `Aliasor(<file>)`.

I added the ability to specify a url via `Aliasor(alias_url=<url>)`.

The use of required, named arguments should be implemented if you want to add different input data such as `str` (which can then be implemented as `Aliasor(alias_string=<str>)`). This makes it very clear what the caller wants to do.

### Related issue(s)  

### Testing
I added a test which takes in the default url currently provided, and tested that compress and uncompress logic still works correctly. I also updated the file constructor test to use the new required, named argument implementation.