### PR TITLE
Functionality to Identify and Assign New Aliases

### DIFF
--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -26,9 +26,9 @@ class Aliasor:
     def compress(self, name, assign=False):
         """
         Returns the compressed lineage name. 
-        Set assign to True to automatically define new compressions for otherwise unhandled designations. 
-        For example, if you want to compress 'BA.5.2.5.6', and if BA.5.2.5 were not aliased, 
-        it would assign BA.5.2.5 to the next available code (in this example, EN) and return EN.5.6.
+        Set assign to True to automatically define new aliases for otherwise unhandled designations. 
+        For example, if you want to compress 'BA.5.2.5.6', and if BA.5.2.5 were not an accepted alias, 
+        it would assign BA.5.2.5 to the next available code (in this example, EN) and return EN.6.
         Recombinant lineages (prefixed with 'X') are treated as a separate set of available aliases
         and will always return an alias prefixed with 'X'.
         """
@@ -41,7 +41,7 @@ class Aliasor:
         ending = ".".join(name_split[(3 * num_indirections + 1) :])
         if assign and alias not in self.realias_dict:
             #note- this cannot produce lineage aliases prefixed with X, which are handled separately as they represent recombinants.
-            self.assign_compression(alias)
+            self.assign_alias(alias)
         return self.realias_dict[alias] + "." + ending
 
     def uncompress(self, name):
@@ -139,7 +139,7 @@ class Aliasor:
             level += 1
         return num
 
-    def next_available_compression(self, recombinant=False):
+    def next_available_alias(self, recombinant=False):
         """
         Returns the next available alias string. 
         Tracks recombinants separately; set recombinant to True to get the next available recombinant alias.
@@ -151,11 +151,11 @@ class Aliasor:
             current = [Aliasor._stringToNumber(k) for k in self.alias_dict.keys() if k[0] != 'X']
             return Aliasor._numberToString(max(current) + 1)
 
-    def assign_compression(self, name, recombinant=False):
+    def assign_alias(self, name, recombinant=False):
         """
         Assigns the input name to the next available alias. 
         Set recombinant to True to assign it to the next recombinant alias.
         """
-        nextn = self.next_available_compression(recombinant)
+        nextn = self.next_available_alias(recombinant)
         self.alias_dict[nextn] = name
         self.realias_dict[name] = nextn

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -27,7 +27,7 @@ class Aliasor:
         """
         Returns the compressed lineage name. 
         Set assign to True to automatically define new aliases for otherwise unhandled designations. 
-        For example, if you want to compress 'BA.5.2.5.6', and if BA.5.2.5 were not an accepted alias, 
+        For example, if you want to compress 'BA.5.2.5.6', and if BA.5.2.5 did not have an accepted alias, 
         it would assign BA.5.2.5 to the next available code (in this example, EN) and return EN.6.
         Recombinant lineages (prefixed with 'X') are treated as a separate set of available aliases
         and will always return an alias prefixed with 'X'.

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -29,8 +29,6 @@ class Aliasor:
         Set assign to True to automatically define new aliases for otherwise unhandled designations. 
         For example, if you want to compress 'BA.5.2.5.6', and if BA.5.2.5 did not have an accepted alias, 
         it would assign BA.5.2.5 to the next available code (in this example, EN) and return EN.6.
-        Recombinant lineages (prefixed with 'X') are treated as a separate set of available aliases
-        and will always return an alias prefixed with 'X'.
         """
         name_split = name.split(".")
         levels = len(name_split) - 1

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -25,10 +25,12 @@ class Aliasor:
 
     def compress(self, name, assign=False):
         """
-        Returns the compressed lineage name. Set assign to True to automatically define new compressions for otherwise unhandled designations. 
+        Returns the compressed lineage name. 
+        Set assign to True to automatically define new compressions for otherwise unhandled designations. 
         For example, if you want to compress 'BA.5.2.5.6', and if BA.5.2.5 were not aliased, 
         it would assign BA.5.2.5 to the next available code (in this example, EN) and return EN.5.6.
-        Recombinant lineages (prefixed with 'X') are treated as a separate set of available aliases and will always return an alias prefixed with 'X'.
+        Recombinant lineages (prefixed with 'X') are treated as a separate set of available aliases
+        and will always return an alias prefixed with 'X'.
         """
         name_split = name.split(".")
         levels = len(name_split) - 1
@@ -38,7 +40,8 @@ class Aliasor:
         alias = ".".join(name_split[0 : (3 * num_indirections + 1)])
         ending = ".".join(name_split[(3 * num_indirections + 1) :])
         if assign and alias not in self.realias_dict:
-            self.assign_compression(alias, (alias[0]=='X'))
+            #note- this cannot produce lineage aliases prefixed with X, which are handled separately as they represent recombinants.
+            self.assign_compression(alias)
         return self.realias_dict[alias] + "." + ending
 
     def uncompress(self, name):
@@ -138,7 +141,8 @@ class Aliasor:
 
     def next_available_compression(self, recombinant=False):
         """
-        Returns the next available alias string. Tracks recombinants separately; set recombinant to True to get the next available recombinant alias.
+        Returns the next available alias string. 
+        Tracks recombinants separately; set recombinant to True to get the next available recombinant alias.
         """
         if recombinant:
             current = [Aliasor._stringToNumber(k[1:]) for k in self.alias_dict.keys() if k[0] == 'X']
@@ -149,7 +153,8 @@ class Aliasor:
 
     def assign_compression(self, name, recombinant=False):
         """
-        Assigns the input name to the next available alias. Set recombinant to True to set it to the next recombinant alias.
+        Assigns the input name to the next available alias. 
+        Set recombinant to True to assign it to the next recombinant alias.
         """
         nextn = self.next_available_compression(recombinant)
         self.alias_dict[nextn] = name

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -27,8 +27,8 @@ class Aliasor:
         """
         Returns the compressed lineage name. 
         Set assign to True to automatically define new aliases for otherwise unhandled designations. 
-        For example, if you want to compress 'BA.5.2.5.6', and if BA.5.2.5 did not have an accepted alias, 
-        it would assign BA.5.2.5 to the next available code (in this example, EN) and return EN.6.
+        For example, if you want to compress 'BA.5.2.5.6', and BA.5.2.5 does not have an accepted alias, 
+        it will assign BA.5.2.5 to the next available code (in this example, EN) and return EN.6.
         """
         name_split = name.split(".")
         levels = len(name_split) - 1

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -111,7 +111,6 @@ class Aliasor:
         digits = []
         while n:
             digits.append(int(n % b))
-            print(int(n%b))
             n //= b
         #convert the base 23 to an alphabet string
         return "".join([Aliasor._bToChar(d,banned) for d in digits[::-1]])

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -104,7 +104,7 @@ class Aliasor:
         return alias + "." + ".".join(name_split[(3 * up_to + 1) :])
     
     @staticmethod
-    def _charToB(char):        
+    def _charToB(char):
         return ord(char)-65
 
     @staticmethod
@@ -116,20 +116,20 @@ class Aliasor:
         return l
 
     @staticmethod
-    def _numberToString(n, b=23, banned='IOX'):
-        #convert the number to base 23
+    def _numberToString(n, b=26, banned='IOX'):
+        #convert the number to base 26
         if n == 0:
             return [0]
         digits = []
         while n:
             digits.append(int(n % b))
             n //= b
-        #convert the base 23 to an alphabet string
+        #convert the base 26 to an alphabet string, incrementing past banned characters
         return "".join([Aliasor._bToChar(d,banned) for d in digits[::-1]])
 
     @staticmethod
-    def _stringToNumber(cstr, b=23):
-        #convert the string to a base23 number
+    def _stringToNumber(cstr, b=26):
+        #convert the string to a base26 number
         digits = [Aliasor._charToB(c) for c in cstr]
         #add the digits up to make a base10 number
         num = 0

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -95,6 +95,7 @@ def test_parent():
 def test_next_compression():
     aliasor = Aliasor()
     n1 = aliasor.next_available_alias()
+    assert n1 not in aliasor.alias_dict.keys()
     n2 = aliasor.next_available_alias(True)
     assert n2[0] == 'X'
     assert n1 != n2

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -94,7 +94,7 @@ def test_parent():
 
 def test_next_compression():
     aliasor = Aliasor()
-    n1 = aliasor.next_available_compression()
-    n2 = aliasor.next_available_compression(True)
+    n1 = aliasor.next_available_alias()
+    n2 = aliasor.next_available_alias(True)
     assert n2[0] == 'X'
     assert n1 != n2

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -91,3 +91,7 @@ def test_parent():
     assert aliasor.parent('A') == ''
     assert aliasor.parent('B') == ''
     assert aliasor.parent('C.1') == 'B.1.1.1'
+
+def test_next_compression():
+    aliasor = Aliasor()
+    aliasor.next_available_compression()

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -94,4 +94,6 @@ def test_parent():
 
 def test_next_compression():
     aliasor = Aliasor()
-    aliasor.next_available_compression()
+    n1 = aliasor.next_available_compression()
+    n2 = aliasor.next_available_compression(True)
+    assert n1 != n2

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -96,4 +96,5 @@ def test_next_compression():
     aliasor = Aliasor()
     n1 = aliasor.next_available_compression()
     n2 = aliasor.next_available_compression(True)
+    assert n2[0] == 'X'
     assert n1 != n2

--- a/tests/test_aliasor.py
+++ b/tests/test_aliasor.py
@@ -99,3 +99,14 @@ def test_next_compression():
     n2 = aliasor.next_available_alias(True)
     assert n2[0] == 'X'
     assert n1 != n2
+
+def test_assign_compression():
+    aliasor = Aliasor()
+    n1 = aliasor.next_available_alias()
+    aliasor.assign_alias('test')
+    assert aliasor.realias_dict['test'] == n1
+    assert aliasor.alias_dict[n1] == 'test'
+    n2 = aliasor.next_available_alias(True)
+    aliasor.assign_alias('test2',True)
+    assert aliasor.realias_dict['test2'] == n2
+    assert aliasor.alias_dict[n2] == 'test2'


### PR DESCRIPTION
### Proposed Changes

This pull request includes some additional functionality I wrote for identifying and assigning the next available alias code to arbitrary lineages in the course of working on my automated lineage designation pipeline. You might appreciate its addition to your package to assist in your own designation workflows, as well as for other users, though I would understand if you feel this is outside the scope of this particular tool or have concerns about these methods causing confusion for users who are not interested in designating lineages.

In terms of implementation, it works by converting the Pango aliases into base26 numbers, finding the maximum, and incrementing it by 1 to find the next available alias. It handles banned values (I, O, and X) by incrementing the characters past these when returning alias strings. Recombinant lineages (prefixed with X) are tracked as a separate group, but the same functions are available when the appropriate parameter is set.

It includes two new methods and a small number of hidden helper functions:

1. Aliasor().next_available_alias(recombinant): returns the next available alias string. Set the recombinant parameter to True to get the next available recombinant alias (prefixed with X).
2. Aliasor().assign_alias(name,recombinant): assigns the input name to the next available alias string. Assigns it to the next available recombinant alias if the recombinant parameter is True.

Additionally, it adds a new parameter to compress(), which when True automatically assigns a new alias string in the case of a fourth suffix level with no accepted alias. The default behavior matches the current behavior (raises an error for unhandled fourth suffix levels).

It's worth noting that I did not write code to automatically export an updated alias_key.json, mostly because information about the alias_key.json is lost on loading as you do not store the multiple recombinant parent lineages, and therefore a JSON rebuilt from the attributes of the Aliasor() object would be incomplete. This could be the subject of a future update.

I have followed the guidelines posted [here](https://virological.org/t/pango-lineage-nomenclature-provisional-rules-for-naming-recombinant-lineages/657) and [here](https://www.pango.network/the-pango-nomenclature-system/statement-of-nomenclature-rules/) in developing and testing this code. Please let me know if I missed any additional rules I missed, if there are unhandled cases I am not covering, or if you notice any other problems with these changes.

### Testing

I've updated the tests with

1. a simple check that fetches the next alias and asserts that setting recombinant=True yields an alias with the 'X' prefix while recombinant=False does not.
2. a check that assigns new aliases for both standard and recombinant lineages and asserts that they were stored correctly and assigned to the correct value.