### PR TITLE
Partition lineage namespace

### DIFF
--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -210,4 +210,21 @@ class Aliasor:
         result= [i[0] if i[0] in voc_set else i[1] for i in vd_ordered]
         return result
 
+    """
+    Return relationship between two lineages. ancestor, descendant, outgroup
+    """
+    def relationship(self, subject, predicate):
+        vocs=[subject,predicate]
+        voc_dict = {k:{"exclude":set([]),"query":set(self.expand_compress(k))} for k in vocs}
+        for i,k in enumerate(vocs):
+            if i+1 < len(vocs):
+                kset=voc_dict.get(k).get("query")
+        if subject in voc_dict.get(predicate).get("query")
+            return "descendant"
+        elif predicate in voc_dict.get(subject).get("query")
+            return "ancestor"
+        else:
+            return "outgroup"
+
+
 # %%

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -16,7 +16,7 @@ class Aliasor:
                 pango_dict = json.load(file)
 
         self.alias_dict = {}
-        for column in file.keys():
+        for column in pango_dict.keys():
             if type(pango_dict[column]) is list or pango_dict[column] == "":
                 self.alias_dict[column] = column
             else:

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -110,5 +110,23 @@ class Aliasor:
 
         return alias + "." + ".".join(name_split[(3 * up_to + 1) :])
 
+    def partition_focus(self,vocs): 
+        #instead of prefixes check for proper subsets of expansions, if they exclude them all
+        result={}
+        voc_dict = {k:{"exclude":set([]),"query":set(self.expand_compress(k))} for k in vocs}
+        for i,k in enumerate(vocs):
+            if i+1 < len(vocs):
+                kset=voc_dict.get(k).get("query")
+                for j in vocs[i+1:]:
+                    jset=voc_dict.get(j).get("query")
+                    if jset.issubset(kset):
+                        voc_dict.get(k).get("exclude").update(jset)
+                    if kset.issubset(jset):
+                        voc_dict.get(j).get("exclude").update(kset)
+        for k,v in voc_dict.items():
+            v.get("query").difference_update(v.get("exclude"))
+            result[k]=list(v.get("query"))
+        return result
+
 
 # %%

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -182,4 +182,22 @@ class Aliasor:
             result[compressed]=decompressed
         return result
 
+    """
+    Order a list of vocs by vertical descent so that parent lineages come before their children
+    """
+    def vd_ordering(self,vocs):
+        voc_set=set(vocs)
+        def split_lineage(lineage):
+            """Split a lineage into sortable parts"""
+            return tuple(int(part) if part.isdigit() else part for part in lineage.split('.'))
+
+        def my_key(item):
+            return split_lineage(item[0])
+
+        inv_map = {v: k for k, v in self.map_alias(vocs).items()}
+        vd_ordered = sorted(inv_map.items(), key=my_key)
+        #express the result in terms of the original vocs either aliased or expanded
+        result= [i[0] if i[0] in voc_set else i[1] for i in vd_ordered]
+        return result
+
 # %%

--- a/src/pango_aliasor/aliasor.py
+++ b/src/pango_aliasor/aliasor.py
@@ -219,9 +219,9 @@ class Aliasor:
         for i,k in enumerate(vocs):
             if i+1 < len(vocs):
                 kset=voc_dict.get(k).get("query")
-        if subject in voc_dict.get(predicate).get("query")
+        if subject in voc_dict.get(predicate).get("query"):
             return "descendant"
-        elif predicate in voc_dict.get(subject).get("query")
+        elif predicate in voc_dict.get(subject).get("query"):
             return "ancestor"
         else:
             return "outgroup"


### PR DESCRIPTION
### Description of proposed changes    
Common use of pango_aliasor for me was reconciling lineages that are to be included in a plot with those recorded in a public health table. 
e.g. to_graph=[XBB*, XBB.1.5*, XBB.1.16*]
In such cases  for stack plots it is necessary to partition the records and namespace based on the relations between the labels such that double counting isn't a problem. This code produces a data structure to enable that check.

e.g.
    namer = Aliasor()
    partitions= namer.partition_focus(to_graph)

Each lineage in to_graph would be a key in partitions. The values are lists of existing variants that respect the partitioning suggested by the presence of the other lineages.

For posterity. This may represent mission creep for this package. So it's fine to reject.

